### PR TITLE
Make installable via 'jupyter serverextension'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ After cloning the repository, cd inside of ganymede_nbextension/ then use pip to
 pip install -r requirements.txt .
 `
 
+Depending on your version of Jupyter, you may also have to install the extension with this command:
+
+`
+jupyter serverextension enable --py ganymede
+`
+
 The file jupyter_notebook_config.py is an example configuration file for starting up Jupyter notebook which activates the extension.
 If you already have a configuration file that you are using, append the contents of jupyter_notebook_config.py to your configuration file.
 If your configuration file already contains a list for c.NotebookApp.server_extensions, simply add 'ganymede.ganymede' to that list.

--- a/ganymede/__init__.py
+++ b/ganymede/__init__.py
@@ -1,0 +1,7 @@
+from .ganymede import load_jupyter_server_extension
+
+def _jupyter_server_extension_paths():
+    return [{
+        'module': 'ganymede',
+    }]
+


### PR DESCRIPTION
Enable installation with the `jupyter serverextension` command.  I think this is a change in newer versions of Jupyter.